### PR TITLE
add --disable-example

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,9 @@ pkgconfig_DATA = libdaq.pc
 if BUILD_MODULES
     MODULES_DIR = modules
 endif
-SUBDIRS = api $(MODULES_DIR) example test
+SUBDIRS = api $(MODULES_DIR) test
+if BUILD_EXAMPLE
+    SUBDIRS += example
+endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,11 @@ AM_CONDITIONAL([BUILD_MODULES], [test "$enable_afpacket_module" = yes -o \
 
 LIBS=${save_LIBS}
 
+AC_ARG_ENABLE(example,
+              AS_HELP_STRING([--disable-example],[do not build the example]),
+              [enable_example="$enableval"], [enable_example=yes])
+AM_CONDITIONAL([BUILD_EXAMPLE], [test "$enable_example" = yes])
+
 AC_CHECK_LIB([dl], [dlopen], [LIBDL="-ldl"])
 
 AM_CONDITIONAL([BUILD_SHARED_MODULES], [ test "$enable_shared" = yes ])


### PR DESCRIPTION
Add --disable-example to be able to build daq on toolchains without threads support

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>