### PR TITLE
Divert: use PF_DIVERT socket on FreeBSD 14 and beyond

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,10 @@ AC_ARG_ENABLE(divert-module,
               AS_HELP_STRING([--disable-divert-module],[do not build the bundled Divert module]),
               [enable_divert_module="$enableval"], [enable_divert_module="$DEFAULT_ENABLE"])
 if test "$enable_divert_module" = yes; then
-    AC_CHECK_DECLS([IPPROTO_DIVERT], [], [enable_divert_module=no], [[#include <netinet/in.h>]])
+    AC_CHECK_DECLS([PF_DIVERT], [],
+	AC_CHECK_DECLS([IPPROTO_DIVERT], [], [enable_divert_module=no],
+	    [[#include <netinet/in.h>]]),
+	[[#include <sys/socket.h>]])
 fi
 AM_CONDITIONAL([BUILD_DIVERT_MODULE], [test "$enable_divert_module" = yes])
 AM_COND_IF([BUILD_DIVERT_MODULE], [AC_CONFIG_FILES([modules/divert/libdaq_static_divert.pc])])

--- a/modules/divert/daq_divert.c
+++ b/modules/divert/daq_divert.c
@@ -183,7 +183,11 @@ static int divert_daq_instantiate(const DAQ_ModuleConfig_h modcfg, DAQ_ModuleIns
     dc->passive = (daq_base_api.config_get_mode(modcfg) == DAQ_MODE_PASSIVE);
 
     /* Open the divert socket.  Traffic will not start going to it until we bind it in start(). */
+#ifdef PF_DIVERT
+    if ((dc->sock = socket(PF_DIVERT, SOCK_RAW, 0)) == -1)
+#else
     if ((dc->sock = socket(PF_INET, SOCK_RAW, IPPROTO_DIVERT)) == -1)
+#endif
     {
         SET_ERROR(modinst, "%s: Couldn't open the DIVERT socket: %s", __func__, strerror(errno));
         divert_daq_destroy(dc);


### PR DESCRIPTION
In FreeBSD the API changed a bit: https://cgit.freebsd.org/src/commit/?id=8624f4347e8133911b0554e816f6bedb56dc5fb3

Make libdaq work without warnings.